### PR TITLE
feat: 支持图片资源多尺度匹配并新增调用级scale_range

### DIFF
--- a/module/atom/image.py
+++ b/module/atom/image.py
@@ -34,6 +34,8 @@ class RuleImage:
         self.roi_back = roi_back
         self.threshold = threshold
         self.file = file
+        self.scale_range: tuple[float, float] | tuple[float, float, float] | None = None
+        self.scale_step: float = 0.1
 
 
 
@@ -136,9 +138,10 @@ class RuleImage:
         x, y, w, h = int(x), int(y), int(w), int(h)
         return image[y:y + h, x:x + w]
 
-    def match(self, image: np.array, threshold: float = None) -> bool:
+    def match(self, image: np.array, threshold: float = None, scale_range: tuple[float, float] | tuple[float, float, float] = None) -> bool:
         """
         :param threshold:
+        :param scale_range: (min_scale, max_scale) or (min_scale, max_scale, step)
         :param image:
         :return:
         """
@@ -156,6 +159,44 @@ class RuleImage:
             logger.error(f"Template image is invalid: {mat.shape}") #检测模板尺寸，不合法则不进行匹配，避免两次截图画面完全相同造成模板不合法
             return True  # 如果模板图像无效，直接返回 True
 
+        active_scale_range = scale_range if scale_range is not None else self.scale_range
+        if active_scale_range is not None:
+            if len(active_scale_range) == 3:
+                min_scale, max_scale, step = active_scale_range
+            else:
+                min_scale, max_scale = active_scale_range
+                step = self.scale_step
+            if min_scale > max_scale:
+                min_scale, max_scale = max_scale, min_scale
+            step = step if step > 0 else 0.05
+            best_val = -1
+            best_loc = None
+            best_shape = None
+            cur_scale = min_scale
+            while cur_scale <= max_scale + 1e-8:
+                scaled_w = max(1, int(mat.shape[1] * cur_scale))
+                scaled_h = max(1, int(mat.shape[0] * cur_scale))
+                if scaled_w > source.shape[1] or scaled_h > source.shape[0]:
+                    cur_scale += step
+                    continue
+                scaled_mat = cv2.resize(mat, (scaled_w, scaled_h), interpolation=cv2.INTER_LINEAR)
+                res = cv2.matchTemplate(source, scaled_mat, cv2.TM_CCOEFF_NORMED)
+                _, max_val, _, max_loc = cv2.minMaxLoc(res)
+                if max_val > best_val:
+                    best_val = max_val
+                    best_loc = max_loc
+                    best_shape = (scaled_w, scaled_h)
+                cur_scale += step
+            if self.debug_mode:
+                logger.attr(self.name, f'multi-scale matching score {best_val:.5f}')
+            if best_loc is not None and best_shape is not None and best_val > threshold:
+                self.roi_front[0] = best_loc[0] + self.roi_back[0]
+                self.roi_front[1] = best_loc[1] + self.roi_back[1]
+                self.roi_front[2] = best_shape[0]
+                self.roi_front[3] = best_shape[1]
+                return True
+            return False
+
         res = cv2.matchTemplate(source, mat, cv2.TM_CCOEFF_NORMED)
         min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)  # 最小匹配度，最大匹配度，最小匹配度的坐标，最大匹配度的坐标
         if self.debug_mode:
@@ -164,6 +205,8 @@ class RuleImage:
         if max_val > threshold:
             self.roi_front[0] = max_loc[0] + self.roi_back[0]
             self.roi_front[1] = max_loc[1] + self.roi_back[1]
+            self.roi_front[2] = mat.shape[1]
+            self.roi_front[3] = mat.shape[0]
             return True
         else:
             return False

--- a/tasks/KekkaiActivation/script_task.py
+++ b/tasks/KekkaiActivation/script_task.py
@@ -45,7 +45,7 @@ class ScriptTask(KU, KekkaiActivationAssets):
             self.screenshot()
             if self.appear(self.I_REALM_SHIN):
                 break
-            if self.appear(self.I_SHI_GROWN):
+            if self.appear(self.I_SHI_GROWN,scale_range=(0.6, 1.2, 0.1)):
                 break
             if self.appear_then_click(self.I_UI_BACK_RED, interval=1):
                 continue
@@ -157,7 +157,7 @@ class ScriptTask(KU, KekkaiActivationAssets):
                 break
             if self.appear(self.I_A_AUTO_INVITE):
                 break
-            if self.appear_then_click(self.I_SHI_CARD, interval=1):
+            if self.appear_then_click(self.I_SHI_CARD, scale_range=(0.6, 1.2, 0.1), interval=1):
                 continue
         logger.info('Enter card page')
 

--- a/tasks/KekkaiUtilize/assets.py
+++ b/tasks/KekkaiUtilize/assets.py
@@ -38,27 +38,27 @@ class KekkaiUtilizeAssets:
 
 	# Image Rule Assets
 	# 育成 
-	I_SHI_GROWN = RuleImage(roi_front=(595,291,35,38), roi_back=(530,254,181,198), threshold=0.6, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_grown.png")
+	I_SHI_GROWN = RuleImage(roi_front=(595,291,35,38), roi_back=(530,220,202,267), threshold=0.6, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_grown.png")
 	# 结界卡 
-	I_SHI_CARD = RuleImage(roi_front=(886,290,38,56), roi_back=(870,276,75,86), threshold=0.6, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_card.png")
+	I_SHI_CARD = RuleImage(roi_front=(891,300,31,55), roi_back=(823,210,252,297), threshold=0.6, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_card.png")
 	# description 
-	I_SHI_DEFENSE = RuleImage(roi_front=(294,298,49,56), roi_back=(215,207,208,221), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_defense.png")
+	I_SHI_DEFENSE = RuleImage(roi_front=(303,308,34,52), roi_back=(178,209,261,274), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_shi_defense.png")
 	# 收取经验（没有满的图） 
-	I_CARD_EXP = RuleImage(roi_front=(889,151,57,54), roi_back=(829,107,199,185), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_card_exp.png")
+	I_CARD_EXP = RuleImage(roi_front=(889,151,57,54), roi_back=(829,33,231,257), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_card_exp.png")
 	# 收取体力（没有满） 
-	I_BOX_AP = RuleImage(roi_front=(815,435,57,51), roi_back=(744,364,345,277), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_ap.png")
+	I_BOX_AP = RuleImage(roi_front=(815,435,57,51), roi_back=(744,336,395,216), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_ap.png")
 	# 收取盒子的经验（没有满） 
-	I_BOX_EXP = RuleImage(roi_front=(993,452,31,54), roi_back=(862,396,249,216), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_exp.png")
+	I_BOX_EXP = RuleImage(roi_front=(893,440,42,45), roi_back=(792,334,359,232), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_exp.png")
 	# 结界皮肤 
-	I_REALM_SHIN = RuleImage(roi_front=(175,460,54,58), roi_back=(22,380,393,308), threshold=0.9, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_realm_shin.png")
+	I_REALM_SHIN = RuleImage(roi_front=(175,460,54,58), roi_back=(22,359,393,328), threshold=0.9, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_realm_shin.png")
 	# 寄养别人的经验 
-	I_UTILIZE_EXP = RuleImage(roi_front=(583,144,58,43), roi_back=(531,112,251,215), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_utilize_exp.png")
+	I_UTILIZE_EXP = RuleImage(roi_front=(583,144,58,43), roi_back=(513,43,280,309), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_utilize_exp.png")
 	# 取出 
 	I_AP_EXTRACT = RuleImage(roi_front=(592,501,100,75), roi_back=(592,501,100,75), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_ap_extract.png")
 	# 提取 
 	I_EXP_EXTRACT = RuleImage(roi_front=(592,448,100,73), roi_back=(592,448,100,73), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_exp_extract.png")
 	# 盒子经验满 
-	I_BOX_EXP_MAX = RuleImage(roi_front=(991,452,38,53), roi_back=(829,372,254,249), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_exp_max.png")
+	I_BOX_EXP_MAX = RuleImage(roi_front=(889,430,61,64), roi_back=(796,326,405,330), threshold=0.7, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_box_exp_max.png")
 	# 种树活动关闭标识 
 	I_PLANT_TREE_CLOSE = RuleImage(roi_front=(777,91,36,34), roi_back=(711,52,169,125), threshold=0.8, method="Template matching", file="./tasks/KekkaiUtilize/realm/realm_plant_tree_close.png")
 

--- a/tasks/KekkaiUtilize/page.py
+++ b/tasks/KekkaiUtilize/page.py
@@ -5,6 +5,8 @@ from tasks.KekkaiUtilize.assets import KekkaiUtilizeAssets
 
 # 阴阳寮结界页面
 page_guild_realm = Page(KekkaiUtilizeAssets.I_REALM_SHIN)
+KekkaiUtilizeAssets.I_SHI_GROWN.scale_range = (0.6, 1.2, 0.1)
+KekkaiUtilizeAssets.I_SHI_CARD.scale_range = (0.6, 1.2, 0.1)
 page_guild_realm.link(button=GlobalGameAssets.I_UI_BACK_YELLOW, destination=page_guild)
 page_guild.link(button=KekkaiUtilizeAssets.I_GUILD_REALM, destination=page_guild_realm)
 # 结界育成页面

--- a/tasks/KekkaiUtilize/realm/image.json
+++ b/tasks/KekkaiUtilize/realm/image.json
@@ -3,7 +3,7 @@
     "itemName": "shi_grown",
     "imageName": "realm_shi_grown.png",
     "roiFront": "595,291,35,38",
-    "roiBack": "530,254,181,198",
+    "roiBack": "530,220,202,267",
     "method": "Template matching",
     "threshold": 0.6,
     "description": "育成"
@@ -11,8 +11,8 @@
   {
     "itemName": "shi_card",
     "imageName": "realm_shi_card.png",
-    "roiFront": "886,290,38,56",
-    "roiBack": "870,276,75,86",
+    "roiFront": "891,300,31,55",
+    "roiBack": "823,210,252,297",
     "method": "Template matching",
     "threshold": 0.6,
     "description": "结界卡"
@@ -20,17 +20,17 @@
   {
     "itemName": "shi_defense",
     "imageName": "realm_shi_defense.png",
-    "roiFront": "294,298,49,56",
-    "roiBack": "215,207,208,221",
+    "roiFront": "303,308,34,52",
+    "roiBack": "178,209,261,274",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "description"
   },
   {
     "itemName": "card_exp",
     "imageName": "realm_card_exp.png",
     "roiFront": "889,151,57,54",
-    "roiBack": "829,107,199,185",
+    "roiBack": "829,33,231,257",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "收取经验（没有满的图）"
@@ -39,7 +39,7 @@
     "itemName": "box_ap",
     "imageName": "realm_box_ap.png",
     "roiFront": "815,435,57,51",
-    "roiBack": "744,364,345,277",
+    "roiBack": "744,336,395,216",
     "method": "Template matching",
     "threshold": 0.7,
     "description": "收取体力（没有满）"
@@ -47,8 +47,8 @@
   {
     "itemName": "box_exp",
     "imageName": "realm_box_exp.png",
-    "roiFront": "993,452,31,54",
-    "roiBack": "862,396,249,216",
+    "roiFront": "893,440,42,45",
+    "roiBack": "792,334,359,232",
     "method": "Template matching",
     "threshold": 0.7,
     "description": "收取盒子的经验（没有满）"
@@ -57,7 +57,7 @@
     "itemName": "realm_shin",
     "imageName": "realm_realm_shin.png",
     "roiFront": "175,460,54,58",
-    "roiBack": "22,380,393,308",
+    "roiBack": "22,359,393,328",
     "method": "Template matching",
     "threshold": 0.9,
     "description": "结界皮肤"
@@ -66,7 +66,7 @@
     "itemName": "utilize_exp",
     "imageName": "realm_utilize_exp.png",
     "roiFront": "583,144,58,43",
-    "roiBack": "531,112,251,215",
+    "roiBack": "513,43,280,309",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "寄养别人的经验"
@@ -92,8 +92,8 @@
   {
     "itemName": "box_exp_max",
     "imageName": "realm_box_exp_max.png",
-    "roiFront": "991,452,38,53",
-    "roiBack": "829,372,254,249",
+    "roiFront": "889,430,61,64",
+    "roiBack": "796,326,405,330",
     "method": "Template matching",
     "threshold": 0.7,
     "description": "盒子经验满"

--- a/tasks/base_task.py
+++ b/tasks/base_task.py
@@ -158,12 +158,14 @@ class BaseTask(GlobalGameAssets, CostumeBase):
     def appear(self,
                target: RuleImage | RuleGif | RuleOcr,
                interval: float = None,
-               threshold: float = None):
+               threshold: float = None,
+               scale_range: tuple[float, float] | tuple[float, float, float] = None):
         """
 
         :param target: 匹配的目标可以是RuleImage, 也可以是RuleOcr
         :param interval:
         :param threshold:
+        :param scale_range: RuleImage专用，(min_scale, max_scale) 或 (min_scale, max_scale, step)
         :return: interval时间到达且匹配成功则返回True, 否则False
         """
         if interval:
@@ -176,6 +178,8 @@ class BaseTask(GlobalGameAssets, CostumeBase):
                 return False
         if isinstance(target, RuleOcr):
             appear = self.ocr_appear(target, interval)
+        elif isinstance(target, RuleImage):
+            appear = target.match(self.device.image, threshold=threshold, scale_range=scale_range)
         else:
             appear = target.match(self.device.image, threshold=threshold)
 
@@ -189,7 +193,8 @@ class BaseTask(GlobalGameAssets, CostumeBase):
                           action: Union[RuleClick, RuleLongClick] = None,
                           interval: float = None,
                           threshold: float = None,
-                          duration: float = None):
+                          duration: float = None,
+                          scale_range: tuple[float, float] | tuple[float, float, float] = None):
         """
         出现了就点击，默认点击图片的位置，如果添加了click参数，就点击click的位置
         :param duration: 如果是长按，可以手动指定duration，不指定默认.单位是ms！！！！
@@ -197,9 +202,10 @@ class BaseTask(GlobalGameAssets, CostumeBase):
         :param target: 可以是RuleImage后续支持RuleOcr
         :param interval:
         :param threshold:
+        :param scale_range: RuleImage专用，(min_scale, max_scale) 或 (min_scale, max_scale, step)
         :return: True or False
         """
-        appear = self.appear(target, interval=interval, threshold=threshold)
+        appear = self.appear(target, interval=interval, threshold=threshold, scale_range=scale_range)
         if appear and not action:
             x, y = target.coord()
             self.device.click(x, y, control_name=target.name)


### PR DESCRIPTION
-在 RuleImage.match 增加可选 scale_range 参数，支持 (min,max) 与 (min,max,step) 两种格式
-在 BaseTask.appear/appear_then_click 增加 scale_range 透传，可按单次调用启用多尺度匹配
-未设置 scale_range 时保持原有单模板匹配逻辑，兼容旧行为
-为 I_SHI_GROWN、I_SHI_CARD 配置 scale_range=(0.6,1.2,0.1)，适配结界皮肤缩放导致的按钮尺寸变化
-理论上结界皮肤通用，鲤鱼旗看看从主仓库拉吧
@AzurTian 