### PR TITLE
fix(TalismanPass): 调整1500天御魂识别阈值和 ROI 区域

### DIFF
--- a/tasks/TalismanPass/assets.py
+++ b/tasks/TalismanPass/assets.py
@@ -34,7 +34,7 @@ class TalismanPassAssets:
 	# 溢出确认 
 	I_OVERFLOW_CONFIRME = RuleImage(roi_front=(585,410,116,44), roi_back=(585,410,116,44), threshold=0.8, method="Template matching", file="./tasks/TalismanPass/tp/tp_overflow_confirme.png")
 	# 点击随机御魂 
-	I_TP_SOUL_1 = RuleImage(roi_front=(248,501,34,37), roi_back=(165,389,929,168), threshold=0.8, method="Multi-scale template matching", file="./tasks/TalismanPass/tp/tp_tp_soul_1.png")
+	I_TP_SOUL_1 = RuleImage(roi_front=(248,501,34,37), roi_back=(165,389,930,189), threshold=0.7, method="Multi-scale template matching", file="./tasks/TalismanPass/tp/tp_tp_soul_1.png")
 	# 选择中间第二个御魂 
 	I_TP_SOUL_2 = RuleImage(roi_front=(582,438,115,48), roi_back=(570,427,139,71), threshold=0.8, method="Template matching", file="./tasks/TalismanPass/tp/tp_tp_soul_2.png")
 	# 六星御魂标志 

--- a/tasks/TalismanPass/tp/image.json
+++ b/tasks/TalismanPass/tp/image.json
@@ -102,9 +102,9 @@
     "itemName": "tp_soul_1",
     "imageName": "tp_tp_soul_1.png",
     "roiFront": "248,501,34,37",
-    "roiBack": "165,389,929,168",
+    "roiBack": "165,389,930,189",
     "method": "Multi-scale template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "点击随机御魂"
   },
   {


### PR DESCRIPTION
神了，阈值0.8没几个庭院能识别到，改成0.7就全可以