### PR TITLE
feat(RealmRaid): 添加个人突破页面的任务逻辑和页面连接

### DIFF
--- a/tasks/RealmRaid/page.py
+++ b/tasks/RealmRaid/page.py
@@ -1,0 +1,4 @@
+from tasks.GameUi.page import page_shikigami_records, page_realm_raid
+from tasks.GlobalGame.assets import GlobalGameAssets
+
+page_shikigami_records.connect(page_realm_raid, GlobalGameAssets.I_UI_BACK_YELLOW, key="page_shikigami_records->page_realm_raid", cost=2)

--- a/tasks/RealmRaid/script_task.py
+++ b/tasks/RealmRaid/script_task.py
@@ -9,10 +9,11 @@ from tasks.GameUi.default_pages import page_exploration
 from tasks.base_task import BaseTask
 from tasks.Component.GeneralBattle.general_battle import ExitMatcher, GeneralBattle
 from tasks.GameUi.game_ui import GameUi
-from tasks.GameUi.page import page_realm_raid, page_main, page_shikigami_records
+from tasks.GameUi.page import page_realm_raid
 from tasks.RealmRaid.assets import RealmRaidAssets
 from tasks.RealmRaid.config import RealmRaid, AttackNumber, WhenAttackFail
 from tasks.Component.SwitchSoul.switch_soul import SwitchSoul
+from tasks.RealmRaid.page import page_shikigami_records
 
 
 from module.logger import logger
@@ -31,14 +32,30 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RealmRaidAssets):
 
     def run(self):
         con = self.config.realm_raid
+        # 直接进入个人突破页面
+        self.goto_page(page_realm_raid)
+
+        # 在突破页面内先判断票数，如果没有票了或者已经达到攻击次数上限，就直接结束任务
+        if not self.check_ticket(con.raid_config.number_base):
+            logger.warning("剩余突破券不足或已达到攻击次数上限，任务终止。")
+            self.goto_page(page_exploration)
+            self.set_next_run(task='RealmRaid', success=False, finish=True)
+            raise TaskEnd
+
+        # 票数足够，现在开始进行御魂切换
         if con.switch_soul_config.enable:
             self.goto_page(page_shikigami_records)
             self.run_switch_soul(con.switch_soul_config.switch_group_team)
+            logger.info("已完成按分组切换御魂。")
+                
         if con.switch_soul_config.enable_switch_by_name:
             self.goto_page(page_shikigami_records)
             self.run_switch_soul_by_name(con.switch_soul_config.group_name, con.switch_soul_config.team_name)
-
+            logger.info("已完成按名称切换御魂。")
+            
+        # 切换完成后，必须返回突破页面
         self.goto_page(page_realm_raid)
+        logger.info("已返回个人结界突破页面。")
 
         # 有呱太活动的时候第一次进入还会 出现一个弹窗
         self.screenshot()

--- a/tasks/RealmRaid/script_task.py
+++ b/tasks/RealmRaid/script_task.py
@@ -37,7 +37,6 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RealmRaidAssets):
 
         # 在突破页面内先判断票数，如果没有票了或者已经达到攻击次数上限，就直接结束任务
         if not self.check_ticket(con.raid_config.number_base):
-            logger.warning("剩余突破券不足或已达到攻击次数上限，任务终止。")
             self.goto_page(page_exploration)
             self.set_next_run(task='RealmRaid', success=False, finish=True)
             raise TaskEnd
@@ -46,16 +45,13 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RealmRaidAssets):
         if con.switch_soul_config.enable:
             self.goto_page(page_shikigami_records)
             self.run_switch_soul(con.switch_soul_config.switch_group_team)
-            logger.info("已完成按分组切换御魂。")
                 
         if con.switch_soul_config.enable_switch_by_name:
             self.goto_page(page_shikigami_records)
             self.run_switch_soul_by_name(con.switch_soul_config.group_name, con.switch_soul_config.team_name)
-            logger.info("已完成按名称切换御魂。")
             
         # 切换完成后，必须返回突破页面
         self.goto_page(page_realm_raid)
-        logger.info("已返回个人结界突破页面。")
 
         # 有呱太活动的时候第一次进入还会 出现一个弹窗
         self.screenshot()


### PR DESCRIPTION
-逻辑更改为先进行突破票判断再执行御魂切换
-添加式神录到个人突破页面的page

不添加 page 会出现下图这种情况浪费时间
<img width="470" height="261" alt="image" src="https://github.com/user-attachments/assets/de1e70dd-a912-402c-9620-39766a16bb09" />

更改逻辑 是为了 节省没票的时候还进行御魂切换
测试过了 无问题 
<img width="505" height="384" alt="image" src="https://github.com/user-attachments/assets/7200be20-5324-4aa8-94c5-2866a0911699" />
