### PR TITLE
fix(BaseExploration): 修复退出探索逻辑，确保正确返回入口页面

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -384,7 +384,20 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
         # 已经打过boss了且设置了不收集小纸人奖励则直接返回
         if self.fire_monster_type == 'boss' and not self._config.exploration_config.collect_paper_reward:
             logger.info("Not collect paper doll reward")
-            self.goto_page(pages.page_exp_entrance)
+            self.goto_page(pages.page_exp_exit) # 前往探索退出弹窗
+            self.click(self.I_E_EXIT_CONFIRM, interval=1)   # 确认退出探索
+            # 等待回到入口或者探索界面
+            for i in range(10):
+                self.screenshot()
+                current_page = self.get_current_page()
+                # 如果在探索页面则前往章节入口
+                if current_page == pages.page_exploration:
+                    self.goto_page(pages.page_exp_entrance)
+                    break
+                # 如果在章节入口页面则直接跳出循环
+                if current_page == pages.page_exp_entrance:
+                    break
+                time.sleep(0.2)
             return True
         # 没打boss或者收集纸人奖励, 且出现了纸人则处理掉落奖励
         if self.appear(self.I_BATTLE_REWARD) and self._config.exploration_config.collect_paper_reward:


### PR DESCRIPTION
之前有过这种问题就是打完boss后出妖气或者宝箱等  直接退出（不点纸人）不会回到章节入口页面  而是到探索页面
所以self.goto_page(pages.page_exp_entrance)这个代码报warning
然后重新识别页面 然后最后到章节入口页面 这个时间太久了大概4-6s
所以优化一下    测试过了能用      能采用就采用 不能我就自用  想不到更好的办法了 
<img width="755" height="1125" alt="@)KKT}_GD@0%XDQ4UERSC1R" src="https://github.com/user-attachments/assets/15a0b73c-c885-4486-95e2-0b36df3f2574" />
